### PR TITLE
Correct typo firwmare in the tags table schema

### DIFF
--- a/tags-table-schema.json
+++ b/tags-table-schema.json
@@ -59,7 +59,7 @@
       "example": "GDL2.3"
     },
     {
-      "name": "firwmare",
+      "name": "firmware",
       "description": "The tag firmware and version used during the deployment.",
       "type": "string",
       "constraints": {


### PR DESCRIPTION
Since this is a change to the standard and I assume one you want to role out as soon as possible, I suggest to release a patch version v0.1.1. Hopefully, it doesn't affect existing datasets.